### PR TITLE
✨feature: 날렸던 payment crud 재작성

### DIFF
--- a/src/main/java/com/sparta/gamjaquick/payment/controller/PaymentController.java
+++ b/src/main/java/com/sparta/gamjaquick/payment/controller/PaymentController.java
@@ -1,4 +1,47 @@
 package com.sparta.gamjaquick.payment.controller;
 
+import com.sparta.gamjaquick.common.response.ApiResponseDto;
+import com.sparta.gamjaquick.common.response.MessageType;
+import com.sparta.gamjaquick.payment.dto.request.PaymentCreateRequestDto;
+import com.sparta.gamjaquick.payment.dto.request.PaymentUpdateRequestDto;
+import com.sparta.gamjaquick.payment.dto.response.PaymentResponseDto;
+import com.sparta.gamjaquick.payment.service.PaymentService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/payments")
 public class PaymentController {
+
+    private final PaymentService paymentService;
+
+    @PostMapping("")
+    public ApiResponseDto<PaymentResponseDto> createPayment(@RequestBody @Valid PaymentCreateRequestDto requestDto) {
+        PaymentResponseDto result = paymentService.createPayment(requestDto);
+        return ApiResponseDto.success(MessageType.CREATE, result);
+    }
+
+    @GetMapping("/{paymentId}")
+    public ApiResponseDto<PaymentResponseDto> getPayment(@PathVariable UUID paymentId) {
+        PaymentResponseDto result = paymentService.getPayment(paymentId);
+        return ApiResponseDto.success(MessageType.RETRIEVE, result);
+    }
+
+    @PutMapping("/{paymentId}")
+    public ApiResponseDto<PaymentResponseDto> updatePaymentStatus(
+            @PathVariable UUID paymentId,
+            @RequestBody @Valid PaymentUpdateRequestDto requestDto) {
+        PaymentResponseDto result = paymentService.updatePaymentStatus(paymentId, requestDto);
+        return ApiResponseDto.success(MessageType.UPDATE, result);
+    }
+
+    @DeleteMapping("/{paymentId}")
+    public ApiResponseDto<MessageType> deletePayment(@PathVariable UUID paymentId) {
+        paymentService.deletePayment(paymentId);
+        return ApiResponseDto.success(MessageType.DELETE);
+    }
 }

--- a/src/main/java/com/sparta/gamjaquick/payment/dto/request/PaymentCreateRequestDto.java
+++ b/src/main/java/com/sparta/gamjaquick/payment/dto/request/PaymentCreateRequestDto.java
@@ -6,6 +6,7 @@ import lombok.NoArgsConstructor;
 import java.util.UUID;
 
 @Getter
+@NoArgsConstructor
 public class PaymentCreateRequestDto {
 
     private UUID orderId;

--- a/src/main/java/com/sparta/gamjaquick/payment/dto/request/PaymentUpdateRequestDto.java
+++ b/src/main/java/com/sparta/gamjaquick/payment/dto/request/PaymentUpdateRequestDto.java
@@ -9,4 +9,3 @@ import lombok.NoArgsConstructor;
 public class PaymentUpdateRequestDto {
     private PaymentStatus status;
 }
-

--- a/src/main/java/com/sparta/gamjaquick/payment/dto/response/PaymentResponseDto.java
+++ b/src/main/java/com/sparta/gamjaquick/payment/dto/response/PaymentResponseDto.java
@@ -4,7 +4,6 @@ import com.sparta.gamjaquick.payment.entity.Payment;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.UUID;

--- a/src/main/java/com/sparta/gamjaquick/payment/entity/Payment.java
+++ b/src/main/java/com/sparta/gamjaquick/payment/entity/Payment.java
@@ -3,7 +3,10 @@ package com.sparta.gamjaquick.payment.entity;
 import com.sparta.gamjaquick.common.AuditingFields;
 import com.sparta.gamjaquick.payment.dto.request.PaymentCreateRequestDto;
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.UuidGenerator;
 
 import java.time.LocalDateTime;
@@ -39,6 +42,7 @@ public class Payment extends AuditingFields {
     @Column(name = "payment_key", nullable = false)
     private String paymentKey;
 
+    @Column(name = "is_deleted", nullable = false)
     private boolean isDeleted = false;
 
     public Payment(PaymentCreateRequestDto requestDto) {
@@ -62,4 +66,5 @@ public class Payment extends AuditingFields {
 //    private String failureReason;       // 결제가 실패시 이유(잔액부족, 은행시스템이나 카드사 점검중, 정지된 카드 등등)
 
 }
+
 

--- a/src/main/java/com/sparta/gamjaquick/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/sparta/gamjaquick/payment/repository/PaymentRepository.java
@@ -3,7 +3,6 @@ package com.sparta.gamjaquick.payment.repository;
 import com.sparta.gamjaquick.payment.entity.Payment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -11,4 +10,5 @@ public interface PaymentRepository extends JpaRepository<Payment, UUID> {
 
     Optional<Payment> findById(UUID paymentId); //관리자가 내역 조회
 //    List<Payment> findByStoreId(UUID storeId); //가게주인이 본인 가게에 들어온 내역 조회..는 알아서 조회하시라..
+
 }

--- a/src/main/java/com/sparta/gamjaquick/payment/service/PaymentService.java
+++ b/src/main/java/com/sparta/gamjaquick/payment/service/PaymentService.java
@@ -1,4 +1,54 @@
 package com.sparta.gamjaquick.payment.service;
 
+
+import com.sparta.gamjaquick.global.error.ErrorCode;
+import com.sparta.gamjaquick.global.error.exception.BusinessException;
+import com.sparta.gamjaquick.payment.dto.request.PaymentCreateRequestDto;
+import com.sparta.gamjaquick.payment.dto.request.PaymentUpdateRequestDto;
+import com.sparta.gamjaquick.payment.dto.response.PaymentResponseDto;
+import com.sparta.gamjaquick.payment.entity.Payment;
+import com.sparta.gamjaquick.payment.repository.PaymentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
 public class PaymentService {
+    private final PaymentRepository paymentRepository;
+
+    // 결제 생성
+    public PaymentResponseDto createPayment(PaymentCreateRequestDto paymentRequestDto) {
+        Payment payment = paymentRepository.save(new Payment(paymentRequestDto));
+        return PaymentResponseDto.from(payment);
+    }
+
+    // ID로 조회(고객이나 사장님은 본인이 이용하는 카드사에서 직접 확인하고, 이 조회기능은 관리자용..?)
+    @Transactional(readOnly = true)
+    public PaymentResponseDto getPayment(UUID paymentId) {
+        Payment payment = paymentRepository.findById(paymentId)
+                .orElseThrow (() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND));
+        return PaymentResponseDto.from(payment);
+    }
+
+    // 결제 상태 업데이트
+    public PaymentResponseDto updatePaymentStatus(UUID paymentId, PaymentUpdateRequestDto paymentRequestDto) {
+        Payment payment = paymentRepository.findById(paymentId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND));
+
+        payment.updateStatus(paymentRequestDto.getStatus());
+        return PaymentResponseDto.from(payment);
+    }
+
+    // 결제 삭제
+    public void deletePayment(UUID paymentId) {
+        Payment payment = paymentRepository.findById(paymentId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND));
+
+        payment.changeToDeleted();
+    }
+
 }


### PR DESCRIPTION
날렸던 payment crud 재작성하고 수정사항(서비스단에서는 void 반환-> 컨트롤러에서 dto반환)도 반영했습니다.
주문이나 결제 그 무엇의 crud 작성한 게 안 올라가서 일단 이거 올려두려고 pr올립니다...
오늘 스크럼 때 나온 [ 주문->주문상태 업데이트->주문&결제완료 데이터 반환] 프로세스는 아직 반영중에 있습니다.
오늘 중으로 반영해서 다시 올리도록 하겠습니다...! 감사합니다....!