### PR TITLE
✨feat: s3 연동 및 api 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,9 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
+    // AWS S3
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
     // queryDSL
     implementation "com.querydsl:querydsl-jpa:5.0.0:jakarta"
     implementation "com.querydsl:querydsl-core"

--- a/src/main/java/com/sparta/gamjaquick/common/AuditingFields.java
+++ b/src/main/java/com/sparta/gamjaquick/common/AuditingFields.java
@@ -3,6 +3,7 @@ package com.sparta.gamjaquick.common;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.annotations.Comment;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedBy;
@@ -19,30 +20,36 @@ public abstract class AuditingFields {
     @CreatedDate
     @Column(nullable = false, updatable = false)
     @Temporal(TemporalType.TIMESTAMP)
+    @Comment("생성일")
     private LocalDateTime createdAt;
 
 
     @CreatedBy
     @Column(nullable = false, updatable = false)
+    @Comment("생성자")
     private String createdBy;
 
 
     @LastModifiedDate
     @Column
     @Temporal(TemporalType.TIMESTAMP)
+    @Comment("수정일")
     private LocalDateTime updatedAt;
 
 
     @LastModifiedBy
     @Column
+    @Comment("수정자")
     private String updatedBy;
 
 
     @Column
     @Temporal(TemporalType.TIMESTAMP)
+    @Comment("삭제일")
     private LocalDateTime deletedAt;
 
     @Column
+    @Comment("삭제자")
     private String deletedBy;
 
     public void delete(String deletedBy) {

--- a/src/main/java/com/sparta/gamjaquick/global/error/ErrorCode.java
+++ b/src/main/java/com/sparta/gamjaquick/global/error/ErrorCode.java
@@ -32,9 +32,14 @@ public enum ErrorCode {
     STORE_ALREADY_APPROVED(HttpStatus.CONFLICT, "ST-006", "이미 승인된 가게입니다."),
     STORE_ALREADY_DELETED(HttpStatus.CONFLICT, "ST-007", "이미 삭제된 가게입니다."),
 
-    //메뉴 관련
+    // 메뉴 관련
     MENU_ALREADY_DELETED(HttpStatus.CONFLICT, "MEN-001", "이미 삭제된 메뉴입니다."),
-    MENU_NOT_FOUND(HttpStatus.NOT_FOUND, "MEN-002","해당 메뉴를 찾을 수 없습니다.")
+    MENU_NOT_FOUND(HttpStatus.NOT_FOUND, "MEN-002","해당 메뉴를 찾을 수 없습니다."),
+
+    // 파일 관련
+    FILE_NAME_MISSING(HttpStatus.BAD_REQUEST, "FILE_001", "파일 이름이 없거나 비어 있습니다."),
+    UNSUPPORTED_FILE_FORMAT(HttpStatus.BAD_REQUEST, "FILE_002", "지원하지 않는 포맷 형식입니다."),
+    FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FILE_003", "파일 업로드 중 오류가 발생했습니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/sparta/gamjaquick/infra/ai/client/GoogleAiApiClient.java
+++ b/src/main/java/com/sparta/gamjaquick/infra/ai/client/GoogleAiApiClient.java
@@ -24,6 +24,12 @@ public class GoogleAiApiClient implements AiApiClient {
     private final JsonConvertUtil jsonConvertUtil;
     private final ApiConfig apiConfig;
 
+    /**
+     * GOOGLE AI에 응답 요청
+     * @param prompt 요청 내용
+     * @return AiApiResponseDto
+     */
+    @Override
     public AiApiResponseDto sendRequest(String prompt) {
         AiApiRequestDto aiApiRequestDto = AiApiRequestDto.createRequest(prompt + apiConfig.getInstruction());
         long startTime = System.currentTimeMillis();

--- a/src/main/java/com/sparta/gamjaquick/infra/aws/config/S3Config.java
+++ b/src/main/java/com/sparta/gamjaquick/infra/aws/config/S3Config.java
@@ -1,0 +1,36 @@
+package com.sparta.gamjaquick.infra.aws.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Getter
+@Configuration
+public class S3Config {
+
+    @Value("${aws.credentials.access-key}")
+    private String accessKey;
+    @Value("${aws.credentials.secret-key}")
+    private String accessSecret;
+    @Value("${aws.region.static}")
+    private String region;
+    @Value("${aws.s3.bucket}")
+    private String bucket;
+    @Value("${aws.s3.upload-path}")
+    private String uploadPath;
+
+    @Bean
+    public AmazonS3Client amazonS3Client(){
+        BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, accessSecret);
+        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+                .withRegion(region).enablePathStyleAccess()
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .build();
+    }
+
+}

--- a/src/main/java/com/sparta/gamjaquick/infra/aws/provider/S3FileUploader.java
+++ b/src/main/java/com/sparta/gamjaquick/infra/aws/provider/S3FileUploader.java
@@ -1,0 +1,90 @@
+package com.sparta.gamjaquick.infra.aws.provider;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.util.StringUtils;
+import com.sparta.gamjaquick.global.error.ErrorCode;
+import com.sparta.gamjaquick.global.error.exception.BusinessException;
+import com.sparta.gamjaquick.infra.aws.config.S3Config;
+import com.sparta.gamjaquick.upload.provider.FileUploader;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.Date;
+import java.util.Objects;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@Profile("local") // TODO: 상용 수정
+@RequiredArgsConstructor
+public class S3FileUploader implements FileUploader {
+
+    private final S3Config s3Config;
+    private final AmazonS3 amazonS3;
+
+    /**
+     * AWS S3에 파일 업로드
+     * @param file 업로드 파일
+     * @return 업로드된 파일의 URL
+     */
+    @Override
+    public String uploadFile(MultipartFile file) {
+        if (file.getOriginalFilename() == null || file.getOriginalFilename().isEmpty()) {
+            throw new BusinessException(ErrorCode.FILE_NAME_MISSING);
+        }
+        String fileName = getFileName(file);
+        return uploadFileToS3(fileName, file);
+    }
+
+    // S3에 파일 업로드
+    private String uploadFileToS3(String fileName, MultipartFile file) {
+        try {
+            ObjectMetadata metadata = new ObjectMetadata();
+            metadata.setContentLength(file.getSize());
+            metadata.setContentType(file.getContentType());
+
+            amazonS3.putObject(new PutObjectRequest(s3Config.getBucket(), fileName, file.getInputStream(), metadata)
+                    .withCannedAcl(CannedAccessControlList.Private));
+
+            // 업로드된 파일의 URL 반환
+            return amazonS3.getUrl(s3Config.getBucket(), fileName).toString();
+
+        } catch (IOException e) {
+            log.error("S3 파일 업로드 중 에러 발생: {}", e.getMessage());
+            throw new BusinessException(ErrorCode.FILE_UPLOAD_FAILED);
+        }
+    }
+
+    private String getFileName(MultipartFile file) {
+        System.out.println("file.getContentType() = " + file.getContentType());
+        if (!Objects.requireNonNull(file.getContentType()).startsWith("image")) {
+            throw new BusinessException(ErrorCode.UNSUPPORTED_FILE_FORMAT);
+        }
+        String path = s3Config.getUploadPath();
+        String sanitizedFileName = sanitizeFileName(file.getOriginalFilename());
+        return path + generateUniqueFileName(sanitizedFileName);
+    }
+
+    private String sanitizeFileName(String originalFilename) {
+        return StringUtils.replace(Objects.requireNonNull(originalFilename), " ", "_");
+    }
+
+    private String generateUniqueFileName(String sanitizedFileName) {
+        String extension;
+        String[] parts = sanitizedFileName.split("\\.");
+        if (parts.length > 1) {
+            extension = "." + parts[parts.length - 1];
+        } else {
+            extension = ".jpg";
+        }
+        return new Date().getTime() + "-" + UUID.randomUUID() + extension;
+    }
+
+}

--- a/src/main/java/com/sparta/gamjaquick/upload/controller/FileUploadController.java
+++ b/src/main/java/com/sparta/gamjaquick/upload/controller/FileUploadController.java
@@ -1,0 +1,29 @@
+package com.sparta.gamjaquick.upload.controller;
+
+import com.sparta.gamjaquick.common.response.ApiResponseDto;
+import com.sparta.gamjaquick.common.response.MessageType;
+import com.sparta.gamjaquick.upload.dto.response.UploadResponseDto;
+import com.sparta.gamjaquick.upload.service.FileUploadService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/uploads")
+@RequiredArgsConstructor
+public class FileUploadController {
+
+    private final FileUploadService fileUploadService;
+
+    @PostMapping("")
+    public ApiResponseDto<?> uploadFiles(@RequestParam(value = "files", required = false) List<MultipartFile> files) {
+        List<UploadResponseDto> result = fileUploadService.uploadFiles(files);
+        return ApiResponseDto.success(MessageType.CREATE, result);
+    }
+
+}

--- a/src/main/java/com/sparta/gamjaquick/upload/dto/response/UploadResponseDto.java
+++ b/src/main/java/com/sparta/gamjaquick/upload/dto/response/UploadResponseDto.java
@@ -1,0 +1,20 @@
+package com.sparta.gamjaquick.upload.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class UploadResponseDto {
+
+    private String imageName;
+    private String imageUrl;
+
+    public static UploadResponseDto from(String imageName, String imageUrl) {
+        return UploadResponseDto.builder()
+                .imageName(imageName)
+                .imageUrl(imageUrl)
+                .build();
+    }
+
+}

--- a/src/main/java/com/sparta/gamjaquick/upload/entity/FileInfo.java
+++ b/src/main/java/com/sparta/gamjaquick/upload/entity/FileInfo.java
@@ -1,0 +1,47 @@
+package com.sparta.gamjaquick.upload.entity;
+
+import com.sparta.gamjaquick.common.AuditingFields;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+import org.hibernate.annotations.UuidGenerator;
+
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "p_file_info")
+@Entity
+public class FileInfo extends AuditingFields {
+
+    @Id
+    @UuidGenerator(style = UuidGenerator.Style.TIME)
+    @Comment("파일 정보 고유 ID")
+    private UUID id;
+
+    @Column(nullable = false)
+    @Comment("저장된 파일 이름")
+    private String fileName;
+
+    @Column(nullable = false)
+    @Comment("원본 파일 이름")
+    private String originalFileName;
+
+    @Column(nullable = false)
+    @Comment("파일 저장 경로")
+    private String filePath;
+
+    @Column(nullable = false)
+    @Comment("파일 형식")
+    private String fileType;
+
+    @Column(nullable = false)
+    @Comment("파일 크기 (바이트)")
+    private Long fileSize;
+
+}

--- a/src/main/java/com/sparta/gamjaquick/upload/provider/FileUploader.java
+++ b/src/main/java/com/sparta/gamjaquick/upload/provider/FileUploader.java
@@ -1,0 +1,11 @@
+package com.sparta.gamjaquick.upload.provider;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+public interface FileUploader {
+
+    String uploadFile(MultipartFile file);
+
+}

--- a/src/main/java/com/sparta/gamjaquick/upload/repository/FileRepository.java
+++ b/src/main/java/com/sparta/gamjaquick/upload/repository/FileRepository.java
@@ -1,0 +1,9 @@
+package com.sparta.gamjaquick.upload.repository;
+
+import com.sparta.gamjaquick.upload.entity.FileInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface FileRepository extends JpaRepository<FileInfo, UUID> {
+}

--- a/src/main/java/com/sparta/gamjaquick/upload/service/FileUploadService.java
+++ b/src/main/java/com/sparta/gamjaquick/upload/service/FileUploadService.java
@@ -1,0 +1,28 @@
+package com.sparta.gamjaquick.upload.service;
+
+import com.sparta.gamjaquick.upload.dto.response.UploadResponseDto;
+import com.sparta.gamjaquick.upload.provider.FileUploader;
+import com.sparta.gamjaquick.upload.repository.FileRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class FileUploadService {
+
+    private final FileRepository fileRepository;
+    private final FileUploader fileUploader;
+
+    public List<UploadResponseDto> uploadFiles(List<MultipartFile> files) {
+        return files.stream()
+                .filter(file -> !file.isEmpty())
+                .map(file -> {
+                    String imageUrl = fileUploader.uploadFile(file);
+                    return UploadResponseDto.from(file.getOriginalFilename(), imageUrl);
+                }).toList();
+    }
+
+}


### PR DESCRIPTION
- [x] 파일 업로드 API 추가
- [x] S3 연동 및 업로드 로직 구현

이미지 업로드 시 사용되는 공통 API입니다. 

**사용방법**
Store, Menu를 등록, 수정할 때 이미지 API를 통해 먼저 이미지를 업로드 합니다.
업로드 후 반환되는 imageUrl을 Store, Menu 등록할 때 imageUrl 필드에 넣어서 등록합니다.