### PR TITLE
✨feat : Spring Security 환경 설정 + SecurityConfig 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,13 @@ dependencies {
 
     //Swagger API
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+
+    // Spring Security 및 JWT 관련 의존성
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/sparta/gamjaquick/config/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/sparta/gamjaquick/config/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,4 @@
+package com.sparta.gamjaquick.config.security;
+
+public class CustomAuthenticationEntryPoint {
+}

--- a/src/main/java/com/sparta/gamjaquick/config/security/SecurityConfig.java
+++ b/src/main/java/com/sparta/gamjaquick/config/security/SecurityConfig.java
@@ -1,0 +1,38 @@
+package com.sparta.gamjaquick.config.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    /**
+     * Spring Security의 주요 설정을 정의하는 빈 등록 : SecurityFilterChain
+     */
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                // CSRF 보호 비활성화
+                .csrf(csrf -> csrf.disable())
+                // 요청 권한 설정
+                .authorizeHttpRequests(auth -> auth
+                        // 회원가입 & 로그인은 인증 없이 허용
+                        .requestMatchers("/api/users/signup", "/api/users/login").permitAll()
+                        // 나머지 요청은 인증 필요
+                        .anyRequest().authenticated()
+                );
+
+        return http.build();
+    }
+
+    /**
+     * 비밀번호를 암호화하기 위한 빈 등록 : BCryptPasswordEncoder
+     */
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/sparta/gamjaquick/config/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sparta/gamjaquick/config/security/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,4 @@
+package com.sparta.gamjaquick.config.security.jwt;
+
+public class JwtAuthenticationFilter {
+}

--- a/src/main/java/com/sparta/gamjaquick/config/security/jwt/JwtProperties.java
+++ b/src/main/java/com/sparta/gamjaquick/config/security/jwt/JwtProperties.java
@@ -1,0 +1,4 @@
+package com.sparta.gamjaquick.config.security.jwt;
+
+public class JwtProperties {
+}

--- a/src/main/java/com/sparta/gamjaquick/config/security/jwt/JwtProvider.java
+++ b/src/main/java/com/sparta/gamjaquick/config/security/jwt/JwtProvider.java
@@ -1,0 +1,4 @@
+package com.sparta.gamjaquick.config.security.jwt;
+
+public class JwtProvider {
+}


### PR DESCRIPTION
## <진행작업 요약>

### 1. 의존성 추가 (gradle)
- Spring Security & JWT를 사용하기 위한 의존성 추가
    - JSON 파싱 & 검증을 위한 jjwt 라이브러리 포함했음
    
### 2. BCrypPasswordEncoder 빈 생성하기
- 비밀번호 암호화를 위해 빈으로 등록했음


### 3. SecurityConfig 설정

> Spring Security의 전반적인 설정 관리 파일
> 
- /api/users/signup, /api/users/login API는 인증 없이 접근 가능하도록 설정
    - 나머지 모든 request는 인증하게 했음
- CSRF 비활성화 + 기본 로그인 폼 비활성화 (해야한대서 했는데 문제가 생기면 말해주십시오)

## **<추가 알림 사항>**

`*config/security` 에 어떤 클래스들이 구성되어야할까 조사해보다가 미리 추가해놨는데(jwt 패키지 안의 클래스들) 이건 진행함에 따라 수정될 수 있음을 미리 알립니다.*