### PR TITLE
✨feat : JWT 처리 로직 구현

### DIFF
--- a/src/main/java/com/sparta/gamjaquick/config/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sparta/gamjaquick/config/security/jwt/JwtAuthenticationFilter.java
@@ -1,4 +1,60 @@
-package com.sparta.gamjaquick.config.security.jwt;
+    package com.sparta.gamjaquick.config.security.jwt;
 
-public class JwtAuthenticationFilter {
-}
+    import jakarta.servlet.Filter;
+    import jakarta.servlet.FilterChain;
+    import jakarta.servlet.ServletException;
+    import jakarta.servlet.ServletRequest;
+    import jakarta.servlet.ServletResponse;
+    import jakarta.servlet.http.HttpServletRequest;
+    import jakarta.servlet.http.HttpServletResponse;
+    import lombok.RequiredArgsConstructor;
+    import org.springframework.security.core.context.SecurityContextHolder;
+    import org.springframework.stereotype.Component;
+    import java.io.IOException;
+
+    /**
+     * JWT 인증 필터 클래스
+     * 클라이언트 요청에서 JWT 토큰을 검증 ->  인증 컨텍스트에 설정
+     */
+    @Component
+    @RequiredArgsConstructor
+    public class JwtAuthenticationFilter implements Filter {
+
+        private final JwtProvider jwtProvider;
+
+        /**
+         * 필터 처리 메서드
+         * @param request 클라이언트 요청
+         * @param response 서버 응답
+         * @param chain    필터체인
+         * @throws IOException 입출력 예외처리
+         * @throws ServletException 서블릿 예외
+         */
+        @Override
+        public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+            HttpServletRequest httpRequest = (HttpServletRequest) request;
+            HttpServletResponse httpResponse = (HttpServletResponse) response;
+
+            String token = extractToken(httpRequest);
+
+            // 토큰 검증 & 인증 객체 설정 부분
+            if (token != null && jwtProvider.validateToken(token)) {
+                var authentication = jwtProvider.getAuthentication(token);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+            chain.doFilter(httpRequest, httpResponse);
+        }
+
+        /**
+         * 요청 헤더에서 JWT 토큰을 추출
+         * @param request HTTP 요청 객체
+         * @return JWT 토큰 문자열 or Null
+         */
+        private String extractToken(HttpServletRequest request) {
+            String bearerToken = request.getHeader("Authorization");
+            if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+                return bearerToken.substring(7);
+            }
+            return null;
+        }
+    }

--- a/src/main/java/com/sparta/gamjaquick/config/security/jwt/JwtProperties.java
+++ b/src/main/java/com/sparta/gamjaquick/config/security/jwt/JwtProperties.java
@@ -1,4 +1,15 @@
-package com.sparta.gamjaquick.config.security.jwt;
+    package com.sparta.gamjaquick.config.security.jwt;
 
-public class JwtProperties {
-}
+    import lombok.Getter;
+    import org.springframework.boot.context.properties.ConfigurationProperties;
+    import org.springframework.context.annotation.Configuration;
+
+
+    @Getter
+    @Configuration
+    @ConfigurationProperties(prefix = "jwt")
+    public class JwtProperties {
+
+        private String secretKey;
+        private long expiration;
+    }

--- a/src/main/java/com/sparta/gamjaquick/config/security/jwt/JwtProvider.java
+++ b/src/main/java/com/sparta/gamjaquick/config/security/jwt/JwtProvider.java
@@ -1,4 +1,87 @@
-package com.sparta.gamjaquick.config.security.jwt;
+    package com.sparta.gamjaquick.config.security.jwt;
 
-public class JwtProvider {
-}
+    import io.jsonwebtoken.*;
+    import io.jsonwebtoken.security.Keys;
+    import lombok.RequiredArgsConstructor;
+    import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+    import org.springframework.security.core.Authentication;
+    import org.springframework.security.core.userdetails.UserDetails;
+    import org.springframework.security.core.userdetails.UserDetailsService;
+    import org.springframework.stereotype.Component;
+
+    import javax.crypto.SecretKey;
+    import java.util.Date;
+
+    @Component
+    @RequiredArgsConstructor
+    public class JwtProvider {
+
+        private final JwtProperties jwtProperties;
+        private final UserDetailsService userDetailsService;
+        private final SecretKey secretKey = Keys.hmacShaKeyFor("6B3E3D511FB5EBB3BDFB865F46A54".getBytes());
+
+        /**
+         * JWT 토큰 생성
+         *
+         * @param username 사용자 이름
+         * @param roles    사용자 역할
+         * @return 생성된 JWT 토큰
+         */
+        public String createToken(String username, String roles) {
+            Date now = new Date();
+            Date expiryDate = new Date(now.getTime() + jwtProperties.getExpiration());
+
+            return Jwts.builder()
+                    .setSubject(username)
+                    .claim("roles", roles)
+                    .setIssuedAt(now)
+                    .setExpiration(expiryDate)
+                    .signWith(secretKey, SignatureAlgorithm.HS256)
+                    .compact();
+        }
+
+        /**
+         * JWT 토큰에서 인증 객체를 생성
+         *
+         * @param token JWT 토큰
+         * @return Authentication 객체
+         */
+        public Authentication getAuthentication(String token) {
+            String username = getUsernameFromToken(token);
+            UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+            return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+        }
+
+        /**
+         * JWT 토큰에서 사용자 이름 추출
+         *
+         * @param token JWT 토큰
+         * @return 사용자 이름
+         */
+        public String getUsernameFromToken(String token) {
+            Claims claims = Jwts.parserBuilder()
+                    .setSigningKey(secretKey)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+            return claims.getSubject();
+        }
+
+        /**
+         * JWT 토큰의 유효성을 검증
+         *
+         * @param token JWT 토큰
+         * @return 유효한 경우 true, 그렇지 않은 경우 false
+         */
+        public boolean validateToken(String token) {
+            try {
+                Jwts.parserBuilder()
+                        .setSigningKey(secretKey)
+                        .build()
+                        .parseClaimsJws(token);
+                return true;
+            } catch (JwtException | IllegalArgumentException e) {
+                return false;
+            }
+        }
+    }


### PR DESCRIPTION
## <진행한 작업 내용 정리>

### 0. 요약

> 여기까지 Spring Security와 Jwt로 뭘했는가

- Spring Security와 JWT를 사용해서 사용자 인증 & 권한 부여 로직을 구현했습니다.
- 회원가입 로그인 API 테스트를 위한 틀이 만들어졌습니다

### 1. JwtProvider 작성 완료

- JWT 토큰 생성 (`createToken`)
- JWT 토큰에서 사용자 정보 추출하기 (`getUsernameFromToken`)
- JWT 검증 로직 (`validateToken`)
- Spring Security 인증 객체 생성하기 (`getAuthentication`)

### 2. JwtAuthenticationFilter 작성완료

- 모든 요청에서 JWT 토큰을 검증 -> 유효한 경우에 인증 객체 생성하기

### 3. JwtProperties 작성완료

- `application.yml` 파일에서 jwt.secret과 jwt.expiration 값을 읽어와서 사용하도록 수정하였음
- JwtProperties 클래스에 expiration 필드와 getter 추가하였음 -> getExpritation method가 없었음..


## <주요 수정 작업 내용>

- JwtProperties 관련 getExpiration 메서드 에러를 해결했습니다. (메서드 부재 원인..)
- JwtAuthenticationFilter의 doFilter 구현으로 abstract 관련 에러가 해결됐습니다.. (관련 내용이 맞는지 정확하지 않은데 doFilter 구현으로 뭔가 해결되긴 했어요)

## <추가 알림 사항> (필독)

> 고정 시크릿 키 관련 내용입니다 노션에 `application.yml` 관련 코드에 추가해두었으니 복붙하시면 됩니다.

- 랜덤 시크릿 키를 하려했으나 너무 어려워서 바로 접고 고정 키로 돌렸습니다.
- 키 변경하면 기존의 JWT 토큰이 모두 무효화 된다고 하니 주의해라고 하는데 아직 와닿지 않네요
- 요구사항에 고정 시크릿 키 방식이 있다는 것을 까먹고 있다가 더 꼬일 뻔 했습니다...

### 다음 작업 내용

- 로그아웃 처리랑 토큰 무효화 기능을 고정 시크릿 키 기반으로 구현된 코드를 PR 올릴 예정입니다.


 